### PR TITLE
Fixed modal height in desktop mode

### DIFF
--- a/src/sass/_сontacts-modals.scss
+++ b/src/sass/_сontacts-modals.scss
@@ -22,6 +22,8 @@
 .modal {
   width: auto;
   height: auto;
+  max-height: 90%;
+  overflow: auto;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -194,6 +196,8 @@ textarea::placeholder {
 .modal_map {
   width: auto;
   height: auto;
+  max-height: 90%;
+  overflow: auto;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -437,7 +441,7 @@ textarea::placeholder {
 
   .modal {
     height: 674px;
-    width: 280px;
+    width: 281px;
     overflow: auto;
     padding: 28px;
   }


### PR DESCRIPTION
Fixed bug when in desktop mode franchise modal was bigger than screen. Also in 320 breakpoint modal width is changed from 280 to 281px to remove horizontal scroll.